### PR TITLE
Fixes for dyndle-tools issue #3

### DIFF
--- a/src/Dyndle.Tools.Core/Utils/CoreServiceClientFactory.cs
+++ b/src/Dyndle.Tools.Core/Utils/CoreServiceClientFactory.cs
@@ -107,10 +107,19 @@ namespace Dyndle.Tools.Core
 
         public static StreamUploadClient GetUploadClient(string url, string username, string password, string domain, string version)
         {
+            BasicHttpSecurity security = null;
+            if(url.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase)) 
+            {
+                security = new BasicHttpSecurity 
+                {
+                    Mode = BasicHttpSecurityMode.Transport
+                };
+            }
             StreamUploadClient uploadClient = new StreamUploadClient((Binding)new BasicHttpBinding()
             {
                 MessageEncoding = WSMessageEncoding.Mtom,
-                TransferMode = TransferMode.StreamedRequest
+                TransferMode = TransferMode.StreamedRequest,
+                Security = security
             }, new EndpointAddress(string.Format("{0}/webservices/CoreService{1}.svc/streamUpload_basicHttp", url, version)));
             // http://localhost/webservices/CoreService201701.svc/streamUpload_basicHttp
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))


### PR DESCRIPTION
**CoreServiceFactory**
Modified streamUpload binding to enable HTTPs

**Installer**
Either creates new or updates existing items during install.

Limited testing locally using CoreService 201701 (Tridion 9.1 GA), so may need some tweaks for compatibility w/ all Dyndle supported versions of Tridion.